### PR TITLE
Removes insert_timestamp

### DIFF
--- a/base-station-ros2/src/base_station_coms/src/base_station_coms.cpp
+++ b/base-station-ros2/src/base_station_coms/src/base_station_coms.cpp
@@ -156,7 +156,6 @@ public:
         request.dest_id = (uint8_t)target_id;
         request.msg_type = msg_type;
         request.packet_len = (uint8_t)std::min(message_len, 31);
-        request.insert_timestamp = true;
         std::memcpy(&request.packet_data, message, request.packet_len);
         
         this->modem_publisher_->publish(request);


### PR DESCRIPTION
### Description: 
Removes insert_timestamp which has been depreciated.
See "Modem Queue Bug Fix" pull request in cougars-ros2 for more details.

### Checklist:
- [ ] Code builds on laptop
- [ ] Code runs on laptop
- [ ] I have updated the documentation as needed.
- [ ] I have performed a self-review of my code.
- [ ] I have resolved any merge conflicts before submission.
- [ ] Node Parameters updated (if applicable)

### Tests:
- [ ] Bench Test without vehicle
- [ ] Bucket Test / Tank Test with vehicle
- [ ] Tested outside
- [ ] Tested in the field

### Required Changes before merge:
- If there are items here then mark as draft pull request

### Additional work possible:
Any changes that could be made in the future to improve the code

### Additional Notes:
Add any additional notes or comments here.

### Related Issues:
Closes # (issue)
